### PR TITLE
Changes to feature/multiple platforms

### DIFF
--- a/Rome.cabal
+++ b/Rome.cabal
@@ -17,6 +17,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     Lib
                        , Data.Cartfile
+                       , Data.GitRepoAvailability
                        , Data.Romefile
                        , Data.TargetPlatform
                        , Data.Ini.Utils

--- a/Rome.cabal
+++ b/Rome.cabal
@@ -1,5 +1,5 @@
 name:                Rome
-version:             0.8.0.17
+version:             0.9.0.18
 synopsis:            An S3 cache for Carthage
 description:         Please see README.md
 homepage:            https://github.com/blender/Rome
@@ -18,6 +18,7 @@ library
   exposed-modules:     Lib
                        , Data.Cartfile
                        , Data.Romefile
+                       , Data.TargetPlatform
                        , Data.Ini.Utils
                        , Text.Parsec.Utils
 
@@ -35,6 +36,7 @@ library
                        , conduit >= 1.2
                        , conduit-extra >= 1.1
                        , ini >= 0.3.5
+                       , split >= 0.2.1.3
                        , text >= 1.2
                        , time >= 1.5.0
                        , transformers >= 0.4

--- a/Rome.cabal
+++ b/Rome.cabal
@@ -37,7 +37,6 @@ library
                        , conduit >= 1.2
                        , conduit-extra >= 1.1
                        , ini >= 0.3.5
-                       , split >= 0.2.1.3
                        , text >= 1.2
                        , time >= 1.5.0
                        , transformers >= 0.4

--- a/src/Data/GitRepoAvailability.hs
+++ b/src/Data/GitRepoAvailability.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE NamedFieldPuns  #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Data.GitRepoAvailability
+    ( GitRepoAvailability (..)
+    , FrameworkAvailability (..)
+    , FrameworkVersion (..)
+    , PlatformAvailability (..)
+    ) where
+
+import Data.Cartfile
+import Data.Romefile
+import Data.TargetPlatform
+
+data GitRepoAvailability = GitRepoAvailability { _availabilityRepo           :: GitRepoName
+                                               , _availabilityVersion        :: Version
+                                               , _repoPlatformAvailabilities :: [PlatformAvailability]
+                                               }
+                                               deriving (Show, Eq)
+
+data FrameworkAvailability = FrameworkAvailability { _availabilityFramework           :: FrameworkVersion
+                                                   , _frameworkPlatformAvailabilities :: [PlatformAvailability]
+                                                   }
+                                                   deriving (Show, Eq)
+
+data FrameworkVersion = FrameworkVersion { _frameworkName    :: FrameworkName
+                                         , _frameworkVersion :: Version
+                                         }
+                                         deriving (Show, Eq)
+
+data PlatformAvailability = PlatformAvailability { _availabilityPlatform :: TargetPlatform
+                                                 , _isAvailable          :: Bool
+                                                 }
+                                                 deriving (Show, Eq)

--- a/src/Data/GitRepoAvailability.hs
+++ b/src/Data/GitRepoAvailability.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE NamedFieldPuns  #-}
-{-# LANGUAGE RecordWildCards #-}
-
 module Data.GitRepoAvailability
     ( GitRepoAvailability (..)
     , FrameworkAvailability (..)

--- a/src/Data/TargetPlatform.hs
+++ b/src/Data/TargetPlatform.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE NamedFieldPuns  #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Data.TargetPlatform
+    ( allTargetPlatforms
+    , readTargetPlatform
+    , targetPlatformName
+    , TargetPlatform (..)
+    ) where
+
+
+import           Control.Monad
+import           Data.Char
+import           Data.Maybe
+
+data TargetPlatform = IOS | Mac | TVOS | WatchOS
+              deriving (Eq, Show)
+
+targetPlatformName :: TargetPlatform -> String
+targetPlatformName IOS = "iOS"
+targetPlatformName Mac = "MacOS"
+targetPlatformName TVOS = "tvOS"
+targetPlatformName WatchOS = "watchOS"
+
+allTargetPlatforms = [IOS, Mac, TVOS, WatchOS]
+
+readTargetPlatform :: String -> Maybe TargetPlatform
+readTargetPlatform str = listToMaybe matchingPlatforms
+  where
+    lowercaseStr = toLower <$> str
+    matchingPlatforms = filter ((==lowercaseStr) . (liftM toLower) . targetPlatformName) allTargetPlatforms

--- a/src/Data/TargetPlatform.hs
+++ b/src/Data/TargetPlatform.hs
@@ -1,31 +1,35 @@
-{-# LANGUAGE NamedFieldPuns  #-}
-{-# LANGUAGE RecordWildCards #-}
-
 module Data.TargetPlatform
     ( allTargetPlatforms
-    , readTargetPlatform
-    , targetPlatformName
     , TargetPlatform (..)
     ) where
 
 
-import           Control.Monad
+
 import           Data.Char
 import           Data.Maybe
+import           Text.Read
+import qualified Text.Read.Lex as L
+
+
 
 data TargetPlatform = IOS | MacOS | TVOS | WatchOS
-              deriving (Ord, Eq, Show)
+              deriving (Ord, Eq)
 
-targetPlatformName :: TargetPlatform -> String
-targetPlatformName IOS = "iOS"
-targetPlatformName MacOS = "macOS"
-targetPlatformName TVOS = "tvOS"
-targetPlatformName WatchOS = "watchOS"
+instance Show TargetPlatform where
+  show IOS      = "iOS"
+  show MacOS    = "macOS"
+  show TVOS     = "tvOS"
+  show WatchOS  = "watchOS"
 
+allTargetPlatforms :: [TargetPlatform]
 allTargetPlatforms = [IOS, MacOS, TVOS, WatchOS]
 
-readTargetPlatform :: String -> Maybe TargetPlatform
-readTargetPlatform str = listToMaybe matchingPlatforms
-  where
-    lowercaseStr = toLower <$> str
-    matchingPlatforms = filter ((==lowercaseStr) . (liftM toLower) . targetPlatformName) allTargetPlatforms
+instance Read TargetPlatform where
+  readPrec = parens $ do
+    L.Ident s <- lexP
+    case map toLower s of
+       "ios"     -> return IOS
+       "macos"   -> return MacOS
+       "tvos"    -> return TVOS
+       "watchos" -> return WatchOS
+       a         -> error $ "Unrecognized platform " ++ a

--- a/src/Data/TargetPlatform.hs
+++ b/src/Data/TargetPlatform.hs
@@ -13,16 +13,16 @@ import           Control.Monad
 import           Data.Char
 import           Data.Maybe
 
-data TargetPlatform = IOS | Mac | TVOS | WatchOS
-              deriving (Eq, Show)
+data TargetPlatform = IOS | MacOS | TVOS | WatchOS
+              deriving (Ord, Eq, Show)
 
 targetPlatformName :: TargetPlatform -> String
 targetPlatformName IOS = "iOS"
-targetPlatformName Mac = "MacOS"
+targetPlatformName MacOS = "MacOS"
 targetPlatformName TVOS = "tvOS"
 targetPlatformName WatchOS = "watchOS"
 
-allTargetPlatforms = [IOS, Mac, TVOS, WatchOS]
+allTargetPlatforms = [IOS, MacOS, TVOS, WatchOS]
 
 readTargetPlatform :: String -> Maybe TargetPlatform
 readTargetPlatform str = listToMaybe matchingPlatforms

--- a/src/Data/TargetPlatform.hs
+++ b/src/Data/TargetPlatform.hs
@@ -18,7 +18,7 @@ data TargetPlatform = IOS | MacOS | TVOS | WatchOS
 
 targetPlatformName :: TargetPlatform -> String
 targetPlatformName IOS = "iOS"
-targetPlatformName MacOS = "MacOS"
+targetPlatformName MacOS = "macOS"
 targetPlatformName TVOS = "tvOS"
 targetPlatformName WatchOS = "watchOS"
 

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -34,6 +34,7 @@ import           Data.Conduit                 (($$))
 import           Data.Conduit.Binary          (sinkFile, sinkLbs, sourceFile,
                                                sourceLbs)
 import           Data.Function
+import           Data.GitRepoAvailability
 import           Data.Ini                     as INI
 import           Data.Ini.Utils               as INI
 import           Data.List
@@ -79,27 +80,6 @@ data RomeListPayload = RomeListPayload { _listMode      :: ListMode
                                        , _listPlatforms :: [TargetPlatform]
                                        }
                                        deriving (Show, Eq)
-
-data GitRepoAvailability = GitRepoAvailability { _availabilityRepo           :: GitRepoName
-                                               , _availabilityVersion        :: Version
-                                               , _repoPlatformAvailabilities :: [PlatformAvailability]
-                                               }
-                                               deriving (Show, Eq)
-
-data FrameworkAvailability = FrameworkAvailability { _availabilityFramework           :: FrameworkVersion
-                                                   , _frameworkPlatformAvailabilities :: [PlatformAvailability]
-                                                   }
-                                                   deriving (Show, Eq)
-
-data FrameworkVersion = FrameworkVersion { _frameworkName    :: FrameworkName
-                                         , _frameworkVersion :: Version
-                                         }
-                                         deriving (Show, Eq)
-
-data PlatformAvailability = PlatformAvailability { _availabilityPlatform :: TargetPlatform
-                                                 , _isAvailable          :: Bool
-                                                 }
-                                                 deriving (Show, Eq)
 
 data ListMode = All
                | Missing

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -1,7 +1,10 @@
 module Main where
 
+import           Control.Monad
+
 import           Lib
 import           Data.Cartfile
+import           Data.GitRepoAvailability
 import           Data.Romefile
 import qualified Data.Text as T
 
@@ -11,29 +14,32 @@ import           Test.QuickCheck
 nonEmptyString :: Gen String
 nonEmptyString = listOf1 arbitrary
 
+instance Arbitrary FrameworkVersion where
+  arbitrary = liftM2 FrameworkVersion arbitrary arbitrary
+
 instance Arbitrary FrameworkName where
   arbitrary = FrameworkName <$> nonEmptyString
 
 instance Arbitrary Version where
   arbitrary = Version <$> nonEmptyString
 
-prop_filterByNameEqualTo_idempotent :: [(FrameworkName, Version)] -> FrameworkName -> Bool
+prop_filterByNameEqualTo_idempotent :: [FrameworkVersion] -> FrameworkName -> Bool
 prop_filterByNameEqualTo_idempotent ls n = filterByNameEqualTo ls n == filterByNameEqualTo (filterByNameEqualTo ls n) n
 
-prop_filterByNameEqualTo_smaller :: [(FrameworkName, Version)] -> FrameworkName -> Bool
+prop_filterByNameEqualTo_smaller :: [FrameworkVersion] -> FrameworkName -> Bool
 prop_filterByNameEqualTo_smaller ls n = length (filterByNameEqualTo ls n) <= length ls
 
-prop_filterByNameEqualTo_model :: [(FrameworkName, Version)] -> FrameworkName -> Bool
-prop_filterByNameEqualTo_model ls n = map fst (filterByNameEqualTo ls n) == filter (== n) (map fst ls)
+prop_filterByNameEqualTo_model :: [FrameworkVersion] -> FrameworkName -> Bool
+prop_filterByNameEqualTo_model ls n = map _frameworkName (filterByNameEqualTo ls n) == filter (== n) (map _frameworkName ls)
 
-prop_filterOutFrameworkNamesAndVersionsIfNotIn_idempotent :: [(FrameworkName, Version)] -> [FrameworkName] -> Bool
+prop_filterOutFrameworkNamesAndVersionsIfNotIn_idempotent :: [FrameworkVersion] -> [FrameworkName] -> Bool
 prop_filterOutFrameworkNamesAndVersionsIfNotIn_idempotent ls ns = filterOutFrameworkNamesAndVersionsIfNotIn ls ns == filterOutFrameworkNamesAndVersionsIfNotIn (filterOutFrameworkNamesAndVersionsIfNotIn ls ns) ns
 
-prop_filterOutFrameworkNamesAndVersionsIfNotIn_smaller :: [(FrameworkName, Version)] -> [FrameworkName] -> Bool
+prop_filterOutFrameworkNamesAndVersionsIfNotIn_smaller :: [FrameworkVersion] -> [FrameworkName] -> Bool
 prop_filterOutFrameworkNamesAndVersionsIfNotIn_smaller ls ns = length (filterOutFrameworkNamesAndVersionsIfNotIn ls ns) <= length ls
 
-prop_filterOutFrameworkNamesAndVersionsIfNotIn_model :: [(FrameworkName, Version)] -> [FrameworkName] -> Bool
-prop_filterOutFrameworkNamesAndVersionsIfNotIn_model ls ns = map fst (filterOutFrameworkNamesAndVersionsIfNotIn ls ns) == filter (`notElem` ns) (map fst ls)
+prop_filterOutFrameworkNamesAndVersionsIfNotIn_model :: [FrameworkVersion] -> [FrameworkName] -> Bool
+prop_filterOutFrameworkNamesAndVersionsIfNotIn_model ls ns = map _frameworkName (filterOutFrameworkNamesAndVersionsIfNotIn ls ns) == filter (`notElem` ns) (map _frameworkName ls)
 
 prop_split_length :: Char -> String -> Property
 prop_split_length sep ls =


### PR DESCRIPTION
- Updated with master
- Removed unused language extensions
- Removed some dependencies
- Made `TargetPlatform` instance of Read and Show (think CustomStringConvertible and StringLiteralConvertible in Swift)
- `rome list --missing|present [<platform>, <platfrom> ...]` removed --platform Option as it was awkward to either specify `--platform iOS --platform watchO`S or `--platform ios,watchos` with no spaces

I'm also open to keep --platform as you have implemented it. What do you think?

Suggestion: Most of the minor changes (like removing parenthesis and so on) were suggested to me by `hlint`. I suppose you don't have it installed.
